### PR TITLE
Add the rdpool resource link to the sidebar

### DIFF
--- a/website/ultradns.erb
+++ b/website/ultradns.erb
@@ -22,6 +22,9 @@
           <li<%= sidebar_current("docs-ultradns-resource-probe-ping") %>>
             <a href="/docs/providers/ultradns/r/probe_ping.html">ultradns_probe_ping</a>
           </li>
+          <li<%= sidebar_current("docs-ultradns-resource-rdpool") %>>
+            <a href="/docs/providers/ultradns/r/rdpool.html">ultradns_rdpool</a>
+          </li>
           <li<%= sidebar_current("docs-ultradns-resource-record") %>>
             <a href="/docs/providers/ultradns/r/record.html">ultradns_record</a>
           </li>


### PR DESCRIPTION
The `ultradns_rdpool` resource is missing from the sidebar of available resources.